### PR TITLE
Make it work with Redmine 3.3.0.stable.1233

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'holidays'
+gem 'holidays', '3.3.0'


### PR DESCRIPTION
If the v5.4 holidays gem is used, then the plugin settings page is broken.
If the v4.7 holidays gem is used, then the Redmine crashes on startup.
No more investigations have been done.
This can be undertood as a patch, because improvements of the holiday gem have been lost.